### PR TITLE
Fix Processes & CodeClient

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">

--- a/src/main/kotlin/dev/ashli/kindling/Main.kt
+++ b/src/main/kotlin/dev/ashli/kindling/Main.kt
@@ -39,7 +39,7 @@ fun main(inputs: Array<String>) {
     val small = shorthandFlags.contains('B') || flags.contains("--basic")
     val large = shorthandFlags.contains('L') || flags.contains("--large")
     val massive = shorthandFlags.contains('M') || flags.contains("--massive")
-    val file = shorthandFlags.contains('f') || flags.contains("--fiAle")
+    val file = shorthandFlags.contains('f') || flags.contains("--file")
     if ((small && large) || (small && massive) || (large && massive)) {
         logError("Only one of --basic, --large, and --massive may be chosen")
         return

--- a/src/main/kotlin/dev/ashli/kindling/Main.kt
+++ b/src/main/kotlin/dev/ashli/kindling/Main.kt
@@ -39,7 +39,7 @@ fun main(inputs: Array<String>) {
     val small = shorthandFlags.contains('B') || flags.contains("--basic")
     val large = shorthandFlags.contains('L') || flags.contains("--large")
     val massive = shorthandFlags.contains('M') || flags.contains("--massive")
-    val file = shorthandFlags.contains('f') || flags.contains("--file")
+    val file = shorthandFlags.contains('f') || flags.contains("--fiAle")
     if ((small && large) || (small && massive) || (large && massive)) {
         logError("Only one of --basic, --large, and --massive may be chosen")
         return

--- a/src/main/kotlin/dev/ashli/kindling/transpiler/codeblocks/header/Process.kt
+++ b/src/main/kotlin/dev/ashli/kindling/transpiler/codeblocks/header/Process.kt
@@ -23,11 +23,23 @@ class Process(val name: String, blocks: List<DFBlock>) : DFHeader(blocks) {
             return Process(dummy.name, blocks)
         }
     }
-    override fun serialize() = "{" +
-            """"id":"block",""" +
-            """"block":"process",""" +
-            """"args":{"items":[]},""" +
-            """"data":${name.serialize()}}""" +
+    override fun serialize() = """{""" +
+        """"id":"block",""" +
+        """"block":"process",""" +
+        """"args":{"items":[""" +
+        """{""" +
+            """"item": {""" +
+            """"id": "bl_tag",""" +
+            """"data": {""" +
+                """"option": "False",""" +
+                """"tag": "Is Hidden",""" +
+                """"action": "dynamic",""" +
+                """"block": "process"""" +
+            """}""" +
+        """}, "slot": 26""" +
+        """}""" +
+        """]},""" +
+        """"data":${name.serialize()}}""" +
             this.code.joinToString("") { "," + it.serialize() }
     override fun technicalName() = name
 

--- a/src/main/kotlin/dev/ashli/kindling/transpiler/codeblocks/normal/StartProcess.kt
+++ b/src/main/kotlin/dev/ashli/kindling/transpiler/codeblocks/normal/StartProcess.kt
@@ -19,26 +19,43 @@ data class StartProcess(val name: String, val params: List<DFValue>) : DFBlock("
             val action = checkStr(inpList[1])
             val params = checkParams(inpList[2], CheckContext(header, "call_func", action))
             val blocks = mutableListOf<DFBlock>()
+            var tagList = listOf(Tag("Copy", "Local Variables", "start_process", "dynamic", null))
+
             for ((paramNum, p) in params.withIndex()) {
-                blocks.add(
-                    SetVar(
-                        "+", listOf(
-                            Variable("^depthCalc", VariableScope.LOCAL),
-                            Variable("^depth $action", VariableScope.LOCAL),
-                            Number(1f)
+                when(p) {
+                    is Tag -> {
+                        tagList = listOf(p) + tagList
+                    }
+                    else -> {
+                        blocks.add(
+                            SetVar(
+                                "+", listOf(
+                                    Variable("^depthCalc", VariableScope.LOCAL),
+                                    Variable("^depth $action", VariableScope.LOCAL),
+                                    Number(1f)
+                                )
+                            )
                         )
-                    )
-                )
-                blocks.add(
-                    SetVar(
-                        "=", listOf(
-                            Variable("^param $action $paramNum %var(^depthCalc)", VariableScope.LOCAL),
-                            p
+                        blocks.add(
+                            SetVar(
+                                "=", listOf(
+                                    Variable("^param $action $paramNum %var(^depthCalc)", VariableScope.LOCAL),
+                                    p
+                                )
+                            )
                         )
-                    )
-                )
+                    }
+                }
             }
-            blocks.add(StartProcess(action, listOf(Tag("Copy", "Local Variables", "start_process", "dynamic", null))))
+
+            if(!tagList.contains(Tag("With current targets", "Target Mode", "start_process", "dynamic", null))
+                && !tagList.contains(Tag("With current selection", "Target Mode", "start_process", "dynamic", null))
+                    && !tagList.contains(Tag("With no targets", "Target Mode", "start_process", "dynamic", null))
+                    && !tagList.contains(Tag("For each in selection", "Target Mode", "start_process", "dynamic", null))) {
+                        tagList = listOf(Tag("With current targets", "Target Mode", "start_process", "dynamic", null)) + tagList
+                }
+
+            blocks.add(StartProcess(action, tagList))
             return blocks
         }
     }


### PR DESCRIPTION
This PR accomplishes two things.

# Fix Processes
Earlier, I reported two issues on the Fire Toolchain discord about Processes malfunctioning. This PR fixes that.

## Links to Issue Reports
https://discord.com/channels/1084627334839140352/1134536658247757934
https://discord.com/channels/1084627334839140352/1134334929833046148

# Fix CodeClient
This PR also introduces a fix to interfacing with the CodeClient API. Earlier, it was based off the API of v1.1 but has been upgraded to match the newest API specifics.

## Quick Note
Currently, CodeClient is a bit bugged in that the last template doesn't place. I added a safety hatch by an extra function that is spawned at the end of CodeClient's running. It's an extra function named `kindling_holder` (or something like that) that explains that there's a bug with CodeClient. It instructs them to say something about it on the discord & ping me in their message so I can fix it. The function will only be visible if they are running a version that fixes it. I did this as I really don't know when this issue will be fixed, whether it be today, tomorrow.